### PR TITLE
Fix broken navigation link

### DIFF
--- a/daohang.html
+++ b/daohang.html
@@ -31,7 +31,7 @@
   <h1>📑 站点目录</h1>
   <ul>
     <li>
-      <a href="./psychological.html">心理学相关文章</a>
+      <a href="./xin-li.html">心理学相关文章</a>
     </li>
   </ul>
 </body>

--- a/feed.json
+++ b/feed.json
@@ -14,7 +14,7 @@
             "url": "https://github.com/Lapyase/test.git/daohang.html",
             "title": "daohang",
             "summary": "📑 站点目录 心理学相关文章",
-            "content_html": "\n  <p>\n    <br>\n<br>\n<br>  \n<br>  \n<br>  \n<br>\n<br>\n<br>  <h1>📑 站点目录</h1>\n<br>  <ul>\n<br>    <li>\n<br>      <a href=\"./psychological.html\">心理学相关文章</a>\n<br>    </li>\n<br>  </ul>\n<br>\n<br>\n<br>\n  </p>",
+            "content_html": "\n  <p>\n    <br>\n<br>\n<br>  \n<br>  \n<br>  \n<br>\n<br>\n<br>  <h1>📑 站点目录</h1>\n<br>  <ul>\n<br>    <li>\n<br>      <a href=\"./xin-li.html\">心理学相关文章</a>\n<br>    </li>\n<br>  </ul>\n<br>\n<br>\n<br>\n  </p>",
             "author": {
                 "name": "Lapy"
             },

--- a/feed.xml
+++ b/feed.xml
@@ -37,7 +37,7 @@
 <br>  <h1>📑 站点目录</h1>
 <br>  <ul>
 <br>    <li>
-<br>      <a href="./psychological.html">心理学相关文章</a>
+<br>      <a href="./xin-li.html">心理学相关文章</a>
 <br>    </li>
 <br>  </ul>
 <br>


### PR DESCRIPTION
## Summary
- fix navigation link in `daohang.html`
- update feed files to point to the correct page

## Testing
- `grep -R "psychological.html" -n`

------
https://chatgpt.com/codex/tasks/task_e_6846c86fd5f0832aa21ca2a0d49436f8